### PR TITLE
docs(api-server): add tips and notes to local setup guide

### DIFF
--- a/src/content/docs/api-server/local-setup.mdx
+++ b/src/content/docs/api-server/local-setup.mdx
@@ -3,7 +3,7 @@ title: Local Setup
 description: A step-by-step guide to configuring and running the API server on your local machine.
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Steps, Aside } from '@astrojs/starlight/components';
 
 This guide will walk you through setting up the API server in a local development environment.
 
@@ -31,13 +31,17 @@ This guide will walk you through setting up the API server in a local developmen
 
     The API server requires a MongoDB database. For local development, the recommended approach is to use Docker.
 
+    <Aside type="tip">
     For a complete walkthrough, follow the [Configure MongoDB for Local Development](/docs/api-server/guides/configure-mongodb) guide.
+    </Aside>
 
 4.  **Configure Environment Variables**
 
     The server uses a `.env` file to manage secrets and configuration. You will need to create this file and populate it with the correct values for your local environment.
 
+    <Aside type="tip">
     For a detailed walkthrough, follow the [Configure Environment Variables](/docs/api-server/guides/configure-environment-variables) guide.
+    </Aside>
 
 5.  **Install Dependencies**
 
@@ -54,12 +58,17 @@ This guide will walk you through setting up the API server in a local developmen
     ```bash
     dart_frog dev
     ```
-
+    <Aside type="note">
     The API will now be running and available at `http://localhost:8080`.
+    </Aside>
 
 7.  **Automatic Database Seeding**
 
     On its first startup, the server automatically connects to your MongoDB database and seeds it with initial data (countries, topics, users, etc.). This process is idempotent, meaning you can safely restart the server multiple times without creating duplicate data.
 
+    <Aside type="tip">
     For more details on how this works, see the [Understand Database Seeding](/docs/api-server/architecture/data-seeding-and-fixtures) guide.
+    </Aside>
+
+
 </Steps>


### PR DESCRIPTION
- Add Aside components with tips and notes throughout the guide
- Improve readability and provide additional helpful information